### PR TITLE
Set working directory for DeserializeLargeBsonObject correctly.

### DIFF
--- a/Src/Newtonsoft.Json.Bson.Tests/BsonDataReaderTests.cs
+++ b/Src/Newtonsoft.Json.Bson.Tests/BsonDataReaderTests.cs
@@ -57,6 +57,9 @@ namespace Newtonsoft.Json.Bson.Tests
         [Test]
         public void DeserializeLargeBsonObject()
         {
+#if !DNXCORE50
+            Directory.SetCurrentDirectory(TestContext.CurrentContext.TestDirectory);
+#endif
             byte[] data = System.IO.File.ReadAllBytes(@"SpaceShipV2.bson");
 
             MemoryStream ms = new MemoryStream(data);


### PR DESCRIPTION
Set to the `TestContext.CurrentContext.TestDirectory` ensures it runs correctly in different runners.

Fixes #1