### PR TITLE
Implement async writing.

### DIFF
--- a/Src/Newtonsoft.Json.Bson/AsyncBinaryWriter.cs
+++ b/Src/Newtonsoft.Json.Bson/AsyncBinaryWriter.cs
@@ -1,0 +1,135 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if HAVE_ASYNC
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Bson
+{
+    // This is not a intended as a general-purpose binary writer, caution should be exercised
+    // if adapting for other uses.
+    internal class AsyncBinaryWriter : BinaryWriter
+    {
+        private static readonly byte[] ByteValueBuffer = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 };
+        private byte[] _buffer;
+
+        public AsyncBinaryWriter(Stream stream)
+            : base(stream)
+        {
+        }
+
+        private byte[] Buffer => _buffer ?? (_buffer = new byte[8]);
+
+        public Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return OutStream.FlushAsync(cancellationToken);
+        }
+
+        public Task WriteAsync(bool value, CancellationToken cancellationToken)
+        {
+            return OutStream.WriteAsync(ByteValueBuffer, value ? 1 : 0, 1, cancellationToken);
+        }
+
+        public Task WriteAsync(int value, CancellationToken cancellationToken)
+        {
+            byte[] buffer = Buffer;
+            buffer[0] = (byte)value;
+            buffer[1] = (byte)(value >> 8);
+            buffer[2] = (byte)(value >> 16);
+            buffer[3] = (byte)(value >> 24);
+            return OutStream.WriteAsync(buffer, 0, 4, cancellationToken);
+        }
+
+        public Task WriteAsync(long value, CancellationToken cancellationToken)
+        {
+            byte[] buffer = Buffer;
+            buffer[0] = (byte)value;
+            buffer[1] = (byte)(value >> 8);
+            buffer[2] = (byte)(value >> 16);
+            buffer[3] = (byte)(value >> 24);
+            buffer[4] = (byte)(value >> 32);
+            buffer[5] = (byte)(value >> 40);
+            buffer[6] = (byte)(value >> 48);
+            buffer[7] = (byte)(value >> 56);
+            return OutStream.WriteAsync(buffer, 0, 8, cancellationToken);
+        }
+
+        public Task WriteAsync(byte value, CancellationToken cancellationToken)
+        {
+            Debug.Assert(value <= 18);
+            return OutStream.WriteAsync(ByteValueBuffer, value, 1, cancellationToken);
+        }
+
+        public Task WriteAsync(double value, CancellationToken cancellationToken)
+        {
+            return WriteAsync(BitConverter.DoubleToInt64Bits(value), cancellationToken);
+        }
+
+        public Task WriteAsync(byte[] buffer, CancellationToken cancellationToken)
+        {
+            return OutStream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
+        }
+
+        public Task WriteAsync(byte[] buffer, int index, int count, CancellationToken cancellationToken)
+        {
+            return OutStream.WriteAsync(buffer, index, count, cancellationToken);
+        }
+    }
+
+    internal class AsyncBinaryWriterOwningWriter : AsyncBinaryWriter
+    {
+        private readonly BinaryWriter _writer;
+
+        public AsyncBinaryWriterOwningWriter(BinaryWriter writer)
+            : base(writer.BaseStream)
+        {
+            Debug.Assert(writer.GetType() == typeof(BinaryWriter));
+            _writer = writer;
+        }
+
+#if HAVE_STREAM_READER_WRITER_CLOSE
+        public override void Close()
+        {
+            // Don't call base.Close(). Let this writer decide
+            // whether or not to close the stream.
+            _writer.Close();
+        }
+#endif
+
+        protected override void Dispose(bool disposing)
+        {
+            // Don't call base.Dispose(disposing). Let this writer decide
+            // whether or not to close the stream.
+            _writer.Dispose();
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Bson/BsonBinaryWriter.Async.cs
+++ b/Src/Newtonsoft.Json.Bson/BsonBinaryWriter.Async.cs
@@ -1,0 +1,227 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if HAVE_ASYNC
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Bson.Utilities;
+
+namespace Newtonsoft.Json.Bson
+{
+    internal partial class BsonBinaryWriter
+    {
+        private readonly AsyncBinaryWriter _asyncWriter;
+
+        public Task FlushAsync(CancellationToken cancellationToken)
+        {
+            if (_asyncWriter == null)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return cancellationToken.FromCanceled();
+                }
+
+                Flush();
+                return AsyncUtils.CompletedTask;
+            }
+
+            return _asyncWriter.FlushAsync(cancellationToken);
+        }
+
+        public Task WriteTokenAsync(BsonToken t, CancellationToken cancellationToken)
+        {
+            if (_asyncWriter == null)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return cancellationToken.FromCanceled();
+                }
+
+                WriteToken(t);
+                return AsyncUtils.CompletedTask;
+            }
+
+            CalculateSize(t);
+            return WriteTokenInternalAsync(t, cancellationToken);
+        }
+
+        private Task WriteTokenInternalAsync(BsonToken t, CancellationToken cancellationToken)
+        {
+            switch (t.Type)
+            {
+                case BsonType.Object:
+                    return WriteObjectAsync((BsonObject)t, cancellationToken);
+                case BsonType.Array:
+                    return WriteArrayAsync((BsonArray)t, cancellationToken);
+                case BsonType.Integer:
+                    return _asyncWriter.WriteAsync(Convert.ToInt32(((BsonValue)t).Value, CultureInfo.InvariantCulture), cancellationToken);
+                case BsonType.Long:
+                    return _asyncWriter.WriteAsync(Convert.ToInt64(((BsonValue)t).Value, CultureInfo.InvariantCulture), cancellationToken);
+                case BsonType.Number:
+                    return _asyncWriter.WriteAsync(Convert.ToDouble(((BsonValue)t).Value, CultureInfo.InvariantCulture), cancellationToken);
+                case BsonType.String:
+                    BsonString bsonString = (BsonString)t;
+                    return WriteStringAsync((string)bsonString.Value, bsonString.ByteCount, bsonString.CalculatedSize - 4, cancellationToken);
+                case BsonType.Boolean:
+                    return _asyncWriter.WriteAsync((bool)((BsonValue)t).Value, cancellationToken);
+                case BsonType.Null:
+                case BsonType.Undefined:
+                    return AsyncUtils.CompletedTask;
+                case BsonType.Date:
+                    BsonValue value = (BsonValue)t;
+
+                    long ticks;
+
+                    if (value.Value is DateTime)
+                    {
+                        DateTime dateTime = (DateTime)value.Value;
+                        if (DateTimeKindHandling == DateTimeKind.Utc)
+                        {
+                            dateTime = dateTime.ToUniversalTime();
+                        }
+                        else if (DateTimeKindHandling == DateTimeKind.Local)
+                        {
+                            dateTime = dateTime.ToLocalTime();
+                        }
+
+                        ticks = DateTimeUtils.ConvertDateTimeToJavaScriptTicks(dateTime, false);
+                    }
+                    else
+                    {
+                        DateTimeOffset dateTimeOffset = (DateTimeOffset)value.Value;
+                        ticks = DateTimeUtils.ConvertDateTimeToJavaScriptTicks(dateTimeOffset.UtcDateTime, dateTimeOffset.Offset);
+                    }
+
+                    return _asyncWriter.WriteAsync(ticks, cancellationToken);
+                case BsonType.Binary:
+                    return WriteBinaryAsync((BsonBinary)t, cancellationToken);
+                case BsonType.Oid:
+                    return _asyncWriter.WriteAsync((byte[])((BsonValue)t).Value, cancellationToken);
+                case BsonType.Regex:
+                    return WriteRegexAsync((BsonRegex)t, cancellationToken);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(t), "Unexpected token when writing BSON: {0}".FormatWith(CultureInfo.InvariantCulture, t.Type));
+            }
+        }
+
+        private async Task WriteObjectAsync(BsonObject value, CancellationToken cancellationToken)
+        {
+            await _asyncWriter.WriteAsync(value.CalculatedSize, cancellationToken).ConfigureAwait(false);
+            foreach (BsonProperty property in value)
+            {
+                await _asyncWriter.WriteAsync((byte)property.Value.Type, cancellationToken).ConfigureAwait(false);
+                await WriteStringAsync((string)property.Name.Value, property.Name.ByteCount, null, cancellationToken).ConfigureAwait(false);
+                BsonType propertyType = property.Value.Type;
+                if (propertyType != BsonType.Null & propertyType != BsonType.Undefined)
+                {
+                    await WriteTokenInternalAsync(property.Value, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            await _asyncWriter.WriteAsync((byte)0, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task WriteArrayAsync(BsonArray value, CancellationToken cancellationToken)
+        {
+            await _asyncWriter.WriteAsync(value.CalculatedSize, cancellationToken).ConfigureAwait(false);
+            ulong index = 0;
+            foreach (BsonToken c in value)
+            {
+                await _asyncWriter.WriteAsync((byte)c.Type, cancellationToken).ConfigureAwait(false);
+                await WriteStringAsync(index.ToString(CultureInfo.InvariantCulture), MathUtils.IntLength(index), null, cancellationToken).ConfigureAwait(false);
+                BsonType type = c.Type;
+                if (type != BsonType.Null & type != BsonType.Undefined)
+                {
+                    await WriteTokenInternalAsync(c, cancellationToken).ConfigureAwait(false);
+                }
+                index++;
+            }
+
+            await _asyncWriter.WriteAsync((byte)0, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task WriteBinaryAsync(BsonBinary value, CancellationToken cancellationToken)
+        {
+            byte[] data = (byte[])value.Value;
+            await _asyncWriter.WriteAsync(data.Length, cancellationToken).ConfigureAwait(false);
+            await _asyncWriter.WriteAsync((byte)value.BinaryType, cancellationToken).ConfigureAwait(false);
+            await _asyncWriter.WriteAsync(data, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task WriteRegexAsync(BsonRegex value, CancellationToken cancellationToken)
+        {
+            await WriteStringAsync((string)value.Pattern.Value, value.Pattern.ByteCount, null, cancellationToken).ConfigureAwait(false);
+            await WriteStringAsync((string)value.Options.Value, value.Options.ByteCount, null, cancellationToken).ConfigureAwait(false);
+        }
+
+        private Task WriteStringAsync(string s, int byteCount, int? calculatedlengthPrefix, CancellationToken cancellationToken)
+        {
+            if (calculatedlengthPrefix != null)
+            {
+                return WritePrefixedStringAsync(s, byteCount, calculatedlengthPrefix.GetValueOrDefault(), cancellationToken);
+            }
+
+            return WriteUtf8BytesAsync(s, byteCount, cancellationToken);
+        }
+
+        private async Task WritePrefixedStringAsync(string s, int byteCount, int calculatedlengthPrefix, CancellationToken cancellationToken)
+        {
+            await _asyncWriter.WriteAsync(calculatedlengthPrefix, cancellationToken).ConfigureAwait(false);
+            await WriteUtf8BytesAsync(s, byteCount, cancellationToken).ConfigureAwait(false);
+        }
+
+        private Task WriteUtf8BytesAsync(string s, int byteCount, CancellationToken cancellationToken)
+        {
+            if (s == null)
+            {
+                return _asyncWriter.WriteAsync((byte)0, cancellationToken);
+            }
+
+            if (byteCount <= 255)
+            {
+                if (_largeByteBuffer == null)
+                {
+                    _largeByteBuffer = new byte[256];
+                }
+                else
+                {
+                    _largeByteBuffer[byteCount] = 0;
+                }
+
+                Encoding.GetBytes(s, 0, s.Length, _largeByteBuffer, 0);
+                return _asyncWriter.WriteAsync(_largeByteBuffer, 0, byteCount + 1, cancellationToken);
+            }
+
+            byte[] bytes = new byte[byteCount + 1];
+            Encoding.GetBytes(s, 0, s.Length, bytes, 0);
+            return _asyncWriter.WriteAsync(bytes, cancellationToken);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Bson/BsonBinaryWriter.Async.cs
+++ b/Src/Newtonsoft.Json.Bson/BsonBinaryWriter.Async.cs
@@ -94,30 +94,7 @@ namespace Newtonsoft.Json.Bson
                     return AsyncUtils.CompletedTask;
                 case BsonType.Date:
                     BsonValue value = (BsonValue)t;
-
-                    long ticks;
-
-                    if (value.Value is DateTime)
-                    {
-                        DateTime dateTime = (DateTime)value.Value;
-                        if (DateTimeKindHandling == DateTimeKind.Utc)
-                        {
-                            dateTime = dateTime.ToUniversalTime();
-                        }
-                        else if (DateTimeKindHandling == DateTimeKind.Local)
-                        {
-                            dateTime = dateTime.ToLocalTime();
-                        }
-
-                        ticks = DateTimeUtils.ConvertDateTimeToJavaScriptTicks(dateTime, false);
-                    }
-                    else
-                    {
-                        DateTimeOffset dateTimeOffset = (DateTimeOffset)value.Value;
-                        ticks = DateTimeUtils.ConvertDateTimeToJavaScriptTicks(dateTimeOffset.UtcDateTime, dateTimeOffset.Offset);
-                    }
-
-                    return _asyncWriter.WriteAsync(ticks, cancellationToken);
+                    return _asyncWriter.WriteAsync(TicksFromDateObject(value.Value), cancellationToken);
                 case BsonType.Binary:
                     return WriteBinaryAsync((BsonBinary)t, cancellationToken);
                 case BsonType.Oid:

--- a/Src/Newtonsoft.Json.Bson/BsonBinaryWriter.cs
+++ b/Src/Newtonsoft.Json.Bson/BsonBinaryWriter.cs
@@ -31,7 +31,7 @@ using Newtonsoft.Json.Bson.Utilities;
 
 namespace Newtonsoft.Json.Bson
 {
-    internal class BsonBinaryWriter
+    internal partial class BsonBinaryWriter
     {
         private static readonly Encoding Encoding = new UTF8Encoding(false);
 
@@ -44,6 +44,9 @@ namespace Newtonsoft.Json.Bson
         public BsonBinaryWriter(BinaryWriter writer)
         {
             DateTimeKindHandling = DateTimeKind.Utc;
+#if HAVE_ASYNC
+            _asyncWriter = writer as AsyncBinaryWriter;
+#endif
             _writer = writer;
         }
 

--- a/Src/Newtonsoft.Json.Bson/BsonDataWriter.Async.cs
+++ b/Src/Newtonsoft.Json.Bson/BsonDataWriter.Async.cs
@@ -1,0 +1,185 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if HAVE_ASYNC
+
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Bson.Utilities;
+
+namespace Newtonsoft.Json.Bson
+{
+    public partial class BsonDataWriter
+    {
+        private readonly bool _safeAsync;
+        private bool _finishingAsync;
+
+        /// <summary>
+        /// Asynchronously flushes whatever is in the buffer to the destination and also flushes the destination.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Because BSON documents are written as a single unit, only <see cref="FlushAsync"/>,
+        /// <see cref="CloseAsync"/> and the final <see cref="WriteEndAsync(CancellationToken)"/>,
+        /// <see cref="WriteEndArrayAsync"/> or <see cref="WriteEndObjectAsync"/>
+        /// that finishes writing the document will write asynchronously. Derived classes will not write asynchronously.</remarks>
+        public override Task FlushAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            return _safeAsync ? _writer.FlushAsync(cancellationToken) : base.FlushAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the end of the current JSON object or array.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Because BSON documents are written as a single unit, only <see cref="FlushAsync"/>,
+        /// <see cref="CloseAsync"/> and the final <see cref="WriteEndAsync(CancellationToken)"/>,
+        /// <see cref="WriteEndArrayAsync"/> or <see cref="WriteEndObjectAsync"/>
+        /// that finishes writing the document will write asynchronously. Derived classes will not write asynchronously.</remarks>
+        public override Task WriteEndAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return _safeAsync && Top == 1 ? CompleteAsync(cancellationToken) : base.WriteEndAsync(cancellationToken);
+        }
+
+        private bool WillCloseAll(BsonType type)
+        {
+            if (type != _root.Type)
+            {
+                return false;
+            }
+
+            for (var token = _parent; token != _root; token = token.Parent)
+            {
+                if (token.Type == type) // Will only close as far as here.
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Asynchronously writes the end of an array.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Because BSON documents are written as a single unit, only <see cref="FlushAsync"/>,
+        /// <see cref="CloseAsync"/> and the final <see cref="WriteEndAsync(CancellationToken)"/>,
+        /// <see cref="WriteEndArrayAsync"/> or <see cref="WriteEndObjectAsync"/>
+        /// that finishes writing the document will write asynchronously. Derived classes will not write asynchronously.</remarks>
+        public override Task WriteEndArrayAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            return _safeAsync && WillCloseAll(BsonType.Array) ? CompleteAsync(cancellationToken) : base.WriteEndArrayAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the end of a JSON object.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Because BSON documents are written as a single unit, only <see cref="FlushAsync"/>,
+        /// <see cref="CloseAsync"/> and the final <see cref="WriteEndAsync(CancellationToken)"/>,
+        /// <see cref="WriteEndArrayAsync"/> or <see cref="WriteEndObjectAsync"/>
+        /// that finishes writing the document will write asynchronously. Derived classes will not write asynchronously.</remarks>
+        public override Task WriteEndObjectAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            return _safeAsync && WillCloseAll(BsonType.Object) ? CompleteAsync(cancellationToken) : base.WriteEndObjectAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously closes this writer.
+        /// If <see cref="JsonWriter.CloseOutput"/> is set to <c>true</c>, the destination is also closed.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Because BSON documents are written as a single unit, only <see cref="FlushAsync"/>,
+        /// <see cref="CloseAsync"/> and the final <see cref="WriteEndAsync(CancellationToken)"/>,
+        /// <see cref="WriteEndArrayAsync"/> or <see cref="WriteEndObjectAsync"/>
+        /// that finishes writing the document will write asynchronously. Derived classes will not write asynchronously.</remarks>
+        public override Task CloseAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            if (_safeAsync)
+            {
+                if (AutoCompleteOnClose)
+                {
+                    if (CloseOutput)
+                    {
+                        return CompleteAndCloseOutputAsync(cancellationToken);
+                    }
+
+                    return CompleteAsync(cancellationToken);
+                }
+
+                if (CloseOutput)
+                {
+                    _writer?.Close();
+                }
+
+                return AsyncUtils.CompletedTask;
+            }
+
+            return base.CloseAsync(cancellationToken);
+        }
+
+        private Task CompleteAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return cancellationToken.FromCanceled();
+            }
+
+            int top = Top;
+            if (top == 0)
+            {
+                return AsyncUtils.CompletedTask;
+            }
+
+            _finishingAsync = true;
+            try
+            {
+                while (top-- != 0)
+                {
+                    WriteEnd();
+                }
+            }
+            finally
+            {
+                _finishingAsync = false;
+            }
+
+            return _writer.WriteTokenAsync(_root, cancellationToken);
+        }
+
+        private async Task CompleteAndCloseOutputAsync(CancellationToken cancellationToken)
+        {
+            await CompleteAsync(cancellationToken).ConfigureAwait(false);
+            _writer?.Close();
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Only overrides those methods that can result in the stream being written to, as only they can benefit from async I/O.