### PR TITLE
Bug with ReadAsync and SupportMultipleContent

### DIFF
--- a/Src/Newtonsoft.Json.Bson/BsonDataReader.Async.cs
+++ b/Src/Newtonsoft.Json.Bson/BsonDataReader.Async.cs
@@ -281,7 +281,15 @@ namespace Newtonsoft.Json.Bson
                 case State.ArrayStart:
                 case State.PostValue:
                     ContainerContext context = _currentContext;
-                    return context == null ? AsyncUtils.False : ReadNormalPostValueAsync(context, cancellationToken);
+                    if (context == null)
+                    {
+                        if (SupportMultipleContent)
+                        {
+                            goto case State.Start;
+                        }
+                        return AsyncUtils.False;
+                    }
+                    return ReadNormalPostValueAsync(context, cancellationToken);
                 case State.Complete:
                 case State.Closed:
                 case State.ConstructorStart:


### PR DESCRIPTION
I use BSON for networking, with a BsonDataReader initialized with SupportMultipleContent = true.

When I used BsonDataReader.Read after having deserialized the first received message, this call would block until the next message arrived, which was the expected behavior.

When I changed my code to use ReadAsync, the behavior was not the same: ReadAsync would always return false after the first message.

I compared the two methods (Read and ReadAsync) and I spotted a difference in methods ReadNormal and ReadNormalAsync: in state State.PostValue, ReadNormal handles the SupportMultipleContent property while ReadNormalAsync doesn't. 

This PR patches ReadNormalAsync so that it handles SupportMultipleContent like ReadNormal does.