### PR TITLE
Improving serialization of decimals to increase precision

### DIFF
--- a/Src/Newtonsoft.Json.Bson.Tests/BsonDataReaderAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Bson.Tests/BsonDataReaderAsyncTests.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // Copyright (c) 2017 James Newton-King
 //
 // Permission is hereby granted, free of charge, to any person
@@ -21,7 +22,8 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-#endregion
+
+#endregion License
 
 #if !(NET20 || NET35 || NET40 || PORTABLE40)
 
@@ -30,14 +32,17 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 using System.Text;
+
 #if DNXCORE50
 using Xunit;
 using Test = Xunit.FactAttribute;
 using Assert = Newtonsoft.Json.Bson.Tests.XUnitAssert;
 #else
+
 using NUnit.Framework;
+
 #endif
-using Newtonsoft.Json.Bson;
+
 using System.IO;
 using Newtonsoft.Json.Linq;
 
@@ -143,6 +148,30 @@ namespace Newtonsoft.Json.Bson.Tests
 
             Assert.AreEqual(1, l.Count);
             Assert.AreEqual(g, l[0]);
+        }
+
+        [Test]
+        public async Task ReadDecimalAsync()
+        {
+            byte[] data = HexToBytes("10-00-00-00-13-30-00-92-A9-53-42-34-42-F8-03-00-00-00-00-00-00-10-80-00");
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonDataReader reader = new BsonDataReader(ms);
+            reader.ReadRootValueAsArray = true;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(-28.6051368556538258m, reader.Value);
+            Assert.AreEqual(typeof(decimal), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
         }
 
         [Test]
@@ -933,10 +962,13 @@ namespace Newtonsoft.Json.Bson.Tests
             ms.Seek(0, SeekOrigin.Begin);
 
             BsonDataReader reader = new BsonDataReader(ms);
+
             // object
             await reader.ReadAsync();
+
             // property name
             await reader.ReadAsync();
+
             // string
             await reader.ReadAsync();
             return (string)reader.Value;
@@ -954,8 +986,10 @@ namespace Newtonsoft.Json.Bson.Tests
             ms.Seek(0, SeekOrigin.Begin);
 
             BsonDataReader reader = new BsonDataReader(ms);
+
             // object
             await reader.ReadAsync();
+
             // property name
             await reader.ReadAsync();
             return (string)reader.Value;
@@ -965,6 +999,7 @@ namespace Newtonsoft.Json.Bson.Tests
         public async Task TestReadLenStringValueShortTripleByteAsync()
         {
             StringBuilder sb = new StringBuilder();
+
             //sb.Append('1',127); //first char of euro at the end of the boundry.
             //sb.Append(euro, 5);
             //sb.Append('1',128);
@@ -984,7 +1019,7 @@ namespace Newtonsoft.Json.Bson.Tests
             sb.Append(Euro);
 
             string expected = sb.ToString();
-            Assert.AreEqual(expected, await  WriteAndReadStringValueAsync(expected));
+            Assert.AreEqual(expected, await WriteAndReadStringValueAsync(expected));
         }
 
         [Test]
@@ -997,7 +1032,7 @@ namespace Newtonsoft.Json.Bson.Tests
             sb.Append(Euro);
 
             string expected = sb.ToString();
-            string result = await  WriteAndReadStringValueAsync(expected);
+            string result = await WriteAndReadStringValueAsync(expected);
             Assert.AreEqual(expected, result);
         }
 
@@ -1008,7 +1043,7 @@ namespace Newtonsoft.Json.Bson.Tests
             sb.Append(Euro, 1); //Just one triple byte char in the string.
 
             string expected = sb.ToString();
-            Assert.AreEqual(expected, await  WriteAndReadStringValueAsync(expected));
+            Assert.AreEqual(expected, await WriteAndReadStringValueAsync(expected));
         }
 
         [Test]
@@ -1021,14 +1056,14 @@ namespace Newtonsoft.Json.Bson.Tests
             sb.Append(Euro);
 
             string expected = sb.ToString();
-            Assert.AreEqual(expected, await  WriteAndReadStringValueAsync(expected));
+            Assert.AreEqual(expected, await WriteAndReadStringValueAsync(expected));
         }
 
         [Test]
         public async Task TestReadStringValueAsync()
         {
             string expected = "test";
-            Assert.AreEqual(expected, await  WriteAndReadStringValueAsync(expected));
+            Assert.AreEqual(expected, await WriteAndReadStringValueAsync(expected));
         }
 
         [Test]
@@ -1037,13 +1072,14 @@ namespace Newtonsoft.Json.Bson.Tests
             StringBuilder sb = new StringBuilder();
             sb.Append('t', 150);
             string expected = sb.ToString();
-            Assert.AreEqual(expected, await  WriteAndReadStringValueAsync(expected));
+            Assert.AreEqual(expected, await WriteAndReadStringValueAsync(expected));
         }
 
         [Test]
         public async Task TestReadStringPropertyNameShortTripleByteAsync()
         {
             StringBuilder sb = new StringBuilder();
+
             //sb.Append('1',127); //first char of euro at the end of the boundry.
             //sb.Append(euro, 5);
             //sb.Append('1',128);

--- a/Src/Newtonsoft.Json.Bson.Tests/BsonDataWriterAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Bson.Tests/BsonDataWriterAsyncTests.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // Copyright (c) 2017 James Newton-King
 //
 // Permission is hereby granted, free of charge, to any person
@@ -21,24 +22,32 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-#endregion
+
+#endregion License
 
 #if !(NET20 || NET35 || NET40 || PORTABLE40)
 
 using System;
+
 #if !(NET20 || NET35 || PORTABLE) || NETSTANDARD1_3 || NETSTANDARD2_0
+
 using System.Numerics;
+
 #endif
+
 using System.Text;
 using System.Threading.Tasks;
+
 #if DNXCORE50
 using Xunit;
 using Test = Xunit.FactAttribute;
 using Assert = Newtonsoft.Json.Bson.Tests.XUnitAssert;
 #else
+
 using NUnit.Framework;
+
 #endif
-using Newtonsoft.Json.Bson;
+
 using System.IO;
 using System.Globalization;
 
@@ -104,7 +113,21 @@ namespace Newtonsoft.Json.Bson.Tests
             await writer.WriteEndAsync();
 
             string bson = BytesToHex(ms.ToArray());
-            Assert.AreEqual("8C-00-00-00-12-30-00-FF-FF-FF-FF-FF-FF-FF-7F-12-31-00-FF-FF-FF-FF-FF-FF-FF-7F-10-32-00-FF-FF-FF-7F-10-33-00-FF-FF-FF-7F-10-34-00-FF-00-00-00-10-35-00-7F-00-00-00-02-36-00-02-00-00-00-61-00-01-37-00-00-00-00-00-00-00-F0-45-01-38-00-FF-FF-FF-FF-FF-FF-EF-7F-01-39-00-00-00-00-E0-FF-FF-EF-47-08-31-30-00-01-05-31-31-00-05-00-00-00-00-00-01-02-03-04-09-31-32-00-40-C5-E2-BA-E3-00-00-00-09-31-33-00-40-C5-E2-BA-E3-00-00-00-00", bson);
+            Assert.AreEqual("8C-00-00-00-12-30-00-FF-FF-FF-FF-FF-FF-FF-7F-12-31-00-FF-FF-FF-FF-FF-FF-FF-7F-10-32-00-FF-FF-FF-7F-10-33-00-FF-FF-FF-7F-10-34-00-FF-00-00-00-10-35-00-7F-00-00-00-02-36-00-02-00-00-00-61-00-13-37-00-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-00-00-00-00-01-38-00-FF-FF-FF-FF-FF-FF-EF-7F-01-39-00-00-00-00-E0-FF-FF-EF-47-08-31-30-00-01-05-31-31-00-05-00-00-00-00-00-01-02-03-04-09-31-32-00-40-C5-E2-BA-E3-00-00-00-09-31-33-00-40-C5-E2-BA-E3-00-00-00-00", bson);
+        }
+
+        [Test]
+        public async Task WriteDecimalAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonDataWriter writer = new BsonDataWriter(ms);
+
+            await writer.WriteStartArrayAsync();
+            await writer.WriteValueAsync(-28.6051368556538258m);
+            await writer.WriteEndAsync();
+
+            string bson = BytesToHex(ms.ToArray());
+            Assert.AreEqual("10-00-00-00-13-30-00-92-A9-53-42-34-42-F8-03-00-00-00-00-00-00-10-80-00", bson);
         }
 
         [Test]
@@ -500,6 +523,7 @@ namespace Newtonsoft.Json.Bson.Tests
         }
 
 #if !PORTABLE || NETSTANDARD1_3 || NETSTANDARD2_0
+
         [Test]
         public async Task WriteBigIntegerAsync()
         {
@@ -534,6 +558,7 @@ namespace Newtonsoft.Json.Bson.Tests
 
             Assert.IsFalse(await reader.ReadAsync());
         }
+
 #endif
     }
 }

--- a/Src/Newtonsoft.Json.Bson.Tests/BsonDataWriterTests.cs
+++ b/Src/Newtonsoft.Json.Bson.Tests/BsonDataWriterTests.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // Copyright (c) 2017 James Newton-King
 //
 // Permission is hereby granted, free of charge, to any person
@@ -21,32 +22,41 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-#endregion
+
+#endregion License
 
 using System;
 using System.Collections.Generic;
+
 #if !(NET20 || NET35 || PORTABLE) || NETSTANDARD1_3 || NETSTANDARD2_0
+
 using System.Numerics;
+
 #endif
+
 using System.Text;
 using System.Text.RegularExpressions;
+
 #if DNXCORE50
 using Xunit;
 using Test = Xunit.FactAttribute;
 using Assert = Newtonsoft.Json.Bson.Tests.XUnitAssert;
 #else
+
 using NUnit.Framework;
+
 #endif
-using Newtonsoft.Json.Bson;
+
 using System.IO;
 using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Utilities;
 using Newtonsoft.Json.Tests.TestObjects;
 using System.Globalization;
 using Newtonsoft.Json.Tests.TestObjects.GeoCoding;
+
 #if NET20
 using Newtonsoft.Json.Utilities.LinqBridge;
 #else
+
 using System.Linq;
 using Newtonsoft.Json.Bson.Converters;
 
@@ -91,6 +101,7 @@ namespace Newtonsoft.Json.Bson.Tests
         }
 
 #if !NET20
+
         [Test]
         public void WriteValues()
         {
@@ -115,8 +126,9 @@ namespace Newtonsoft.Json.Bson.Tests
             writer.WriteEnd();
 
             string bson = BytesToHex(ms.ToArray());
-            Assert.AreEqual("8C-00-00-00-12-30-00-FF-FF-FF-FF-FF-FF-FF-7F-12-31-00-FF-FF-FF-FF-FF-FF-FF-7F-10-32-00-FF-FF-FF-7F-10-33-00-FF-FF-FF-7F-10-34-00-FF-00-00-00-10-35-00-7F-00-00-00-02-36-00-02-00-00-00-61-00-01-37-00-00-00-00-00-00-00-F0-45-01-38-00-FF-FF-FF-FF-FF-FF-EF-7F-01-39-00-00-00-00-E0-FF-FF-EF-47-08-31-30-00-01-05-31-31-00-05-00-00-00-00-00-01-02-03-04-09-31-32-00-40-C5-E2-BA-E3-00-00-00-09-31-33-00-40-C5-E2-BA-E3-00-00-00-00", bson);
+            Assert.AreEqual("8C-00-00-00-12-30-00-FF-FF-FF-FF-FF-FF-FF-7F-12-31-00-FF-FF-FF-FF-FF-FF-FF-7F-10-32-00-FF-FF-FF-7F-10-33-00-FF-FF-FF-7F-10-34-00-FF-00-00-00-10-35-00-7F-00-00-00-02-36-00-02-00-00-00-61-00-13-37-00-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-00-00-00-00-01-38-00-FF-FF-FF-FF-FF-FF-EF-7F-01-39-00-00-00-00-E0-FF-FF-EF-47-08-31-30-00-01-05-31-31-00-05-00-00-00-00-00-01-02-03-04-09-31-32-00-40-C5-E2-BA-E3-00-00-00-09-31-33-00-40-C5-E2-BA-E3-00-00-00-00", bson);
         }
+
 #endif
 
         [Test]
@@ -316,6 +328,8 @@ namespace Newtonsoft.Json.Bson.Tests
             Assert.AreEqual("4E-02-00-00-02-30-2D-31-2D-32-2D-33-2D-34-2D-35-2D-36-2D-37-2D-38-2D-39-2D-31-30-2D-31-31-2D-31-32-2D-31-33-2D-31-34-2D-31-35-2D-31-36-2D-31-37-2D-31-38-2D-31-39-2D-32-30-2D-32-31-2D-32-32-2D-32-33-2D-32-34-2D-32-35-2D-32-36-2D-32-37-2D-32-38-2D-32-39-2D-33-30-2D-33-31-2D-33-32-2D-33-33-2D-33-34-2D-33-35-2D-33-36-2D-33-37-2D-33-38-2D-33-39-2D-34-30-2D-34-31-2D-34-32-2D-34-33-2D-34-34-2D-34-35-2D-34-36-2D-34-37-2D-34-38-2D-34-39-2D-35-30-2D-35-31-2D-35-32-2D-35-33-2D-35-34-2D-35-35-2D-35-36-2D-35-37-2D-35-38-2D-35-39-2D-36-30-2D-36-31-2D-36-32-2D-36-33-2D-36-34-2D-36-35-2D-36-36-2D-36-37-2D-36-38-2D-36-39-2D-37-30-2D-37-31-2D-37-32-2D-37-33-2D-37-34-2D-37-35-2D-37-36-2D-37-37-2D-37-38-2D-37-39-2D-38-30-2D-38-31-2D-38-32-2D-38-33-2D-38-34-2D-38-35-2D-38-36-2D-38-37-2D-38-38-2D-38-39-2D-39-30-2D-39-31-2D-39-32-2D-39-33-2D-39-34-2D-39-35-2D-39-36-2D-39-37-2D-39-38-2D-39-39-00-22-01-00-00-30-2D-31-2D-32-2D-33-2D-34-2D-35-2D-36-2D-37-2D-38-2D-39-2D-31-30-2D-31-31-2D-31-32-2D-31-33-2D-31-34-2D-31-35-2D-31-36-2D-31-37-2D-31-38-2D-31-39-2D-32-30-2D-32-31-2D-32-32-2D-32-33-2D-32-34-2D-32-35-2D-32-36-2D-32-37-2D-32-38-2D-32-39-2D-33-30-2D-33-31-2D-33-32-2D-33-33-2D-33-34-2D-33-35-2D-33-36-2D-33-37-2D-33-38-2D-33-39-2D-34-30-2D-34-31-2D-34-32-2D-34-33-2D-34-34-2D-34-35-2D-34-36-2D-34-37-2D-34-38-2D-34-39-2D-35-30-2D-35-31-2D-35-32-2D-35-33-2D-35-34-2D-35-35-2D-35-36-2D-35-37-2D-35-38-2D-35-39-2D-36-30-2D-36-31-2D-36-32-2D-36-33-2D-36-34-2D-36-35-2D-36-36-2D-36-37-2D-36-38-2D-36-39-2D-37-30-2D-37-31-2D-37-32-2D-37-33-2D-37-34-2D-37-35-2D-37-36-2D-37-37-2D-37-38-2D-37-39-2D-38-30-2D-38-31-2D-38-32-2D-38-33-2D-38-34-2D-38-35-2D-38-36-2D-38-37-2D-38-38-2D-38-39-2D-39-30-2D-39-31-2D-39-32-2D-39-33-2D-39-34-2D-39-35-2D-39-36-2D-39-37-2D-39-38-2D-39-39-00-00", bson);
         }
 
+        private const Decimal HighPrecisionLatitude = -28.6051368556538258m;
+
         [Test]
         public void SerializeGoogleGeoCode()
         {
@@ -350,7 +364,7 @@ namespace Newtonsoft.Json.Bson.Tests
         ""Accuracy"": 8
       },
       ""Point"": {
-        ""coordinates"": [-122.083739, 37.423021, 0]
+        ""coordinates"": [-122.083739, -28.6051368556538258, 0]
       }
     }
   ]
@@ -387,7 +401,7 @@ namespace Newtonsoft.Json.Bson.Tests
             Assert.AreEqual("1600 Amphitheatre Pkwy", placemark.AddressDetails.Country.AdministrativeArea.SubAdministrativeArea.Locality.Thoroughfare.ThoroughfareName);
             Assert.AreEqual("94043", placemark.AddressDetails.Country.AdministrativeArea.SubAdministrativeArea.Locality.PostalCode.PostalCodeNumber);
             Assert.AreEqual(-122.083739m, placemark.Point.Coordinates[0]);
-            Assert.AreEqual(37.423021m, placemark.Point.Coordinates[1]);
+            Assert.AreEqual(HighPrecisionLatitude, placemark.Point.Coordinates[1]);
             Assert.AreEqual(0m, placemark.Point.Coordinates[2]);
         }
 
@@ -475,6 +489,7 @@ namespace Newtonsoft.Json.Bson.Tests
             serializer.Serialize(writer, p);
 
             Console.WriteLine(BitConverter.ToString(ms.ToArray()));
+
             // 7C-00-00-00-02-4E-61-6D-65-00-16-00-00-00-43-61-72-6C-
             // 6F-73-27-20-53-70-69-63-79-20-57-69-65-6E-65-72-73-00-
             // 09-45-78-70-69-72-79-44-61-74-65-00-E0-51-BD-76-20-01-
@@ -490,6 +505,7 @@ namespace Newtonsoft.Json.Bson.Tests
             Product deserializedProduct = serializer.Deserialize<Product>(reader);
 
             Console.WriteLine(deserializedProduct.Name);
+
             // Carlos' Spicy Wieners
 
             Assert.AreEqual("Carlos' Spicy Wieners", deserializedProduct.Name);
@@ -805,6 +821,7 @@ namespace Newtonsoft.Json.Bson.Tests
         }
 
 #if !(NET20 || NET35 || PORTABLE || PORTABLE40) || NETSTANDARD1_3 || NETSTANDARD2_0
+
         [Test]
         public void WriteBigInteger()
         {
@@ -873,7 +890,7 @@ namespace Newtonsoft.Json.Bson.Tests
 
             writer.WriteStartObject();
             writer.WritePropertyName("array0");
-            writer.WriteValue(new byte[] {0, 1, 2, 3, 4, 5, 6, 7});
+            writer.WriteValue(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 });
             writer.WritePropertyName("array1");
             writer.WriteValue(default(byte[]));
             writer.WriteEndObject();
@@ -884,7 +901,7 @@ namespace Newtonsoft.Json.Bson.Tests
             Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
             Assert.IsTrue(reader.Read());
             Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
-            Assert.AreEqual(new byte[] {0, 1, 2, 3, 4, 5, 6, 7}, reader.ReadAsBytes());
+            Assert.AreEqual(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 }, reader.ReadAsBytes());
             Assert.IsTrue(reader.Read());
             Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
             Assert.IsNull(reader.ReadAsBytes());
@@ -946,6 +963,7 @@ namespace Newtonsoft.Json.Bson.Tests
             // nothing is written because a BSON document needs to be completed before it can be written
             Assert.AreEqual(string.Empty, (BitConverter.ToString(ms.ToArray())));
         }
+
 #endif
     }
 }

--- a/Src/Newtonsoft.Json.Bson/AsyncBinaryReader.cs
+++ b/Src/Newtonsoft.Json.Bson/AsyncBinaryReader.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // Copyright (c) 2017 James Newton-King
 //
 // Permission is hereby granted, free of charge, to any person
@@ -21,7 +22,8 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-#endregion
+
+#endregion License
 
 #if HAVE_ASYNC
 
@@ -102,6 +104,17 @@ namespace Newtonsoft.Json.Bson
             return buffer[0] | buffer[1] << 8 | buffer[2] << 16 | buffer[3] << 24;
         }
 
+        public async Task<decimal> ReadDecimalAsync(CancellationToken cancellationToken)
+        {
+            var buffer = await ReadBufferAsync(16, cancellationToken).ConfigureAwait(false);
+            var bits = new int[4];
+            for (var i = 0; i <= 15; i += 4)
+            {
+                bits[i / 4] = BitConverter.ToInt32(buffer, i);
+            }
+            return new decimal(bits);
+        }
+
         public async Task<double> ReadDoubleAsync(CancellationToken cancellationToken)
         {
             var buffer = await ReadBufferAsync(8, cancellationToken).ConfigureAwait(false);
@@ -168,12 +181,14 @@ namespace Newtonsoft.Json.Bson
         }
 
 #if HAVE_STREAM_READER_WRITER_CLOSE
+
         public override void Close()
         {
             // Don't call base.Close(). Let this reader decide
             // whether or not to close the stream.
             _reader.Close();
         }
+
 #endif
 
         protected override void Dispose(bool disposing)

--- a/Src/Newtonsoft.Json.Bson/BsonBinaryWriter.Async.cs
+++ b/Src/Newtonsoft.Json.Bson/BsonBinaryWriter.Async.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // Copyright (c) 2017 James Newton-King
 //
 // Permission is hereby granted, free of charge, to any person
@@ -21,15 +22,16 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-#endregion
+
+#endregion License
 
 #if HAVE_ASYNC
 
+using Newtonsoft.Json.Bson.Utilities;
 using System;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Bson.Utilities;
 
 namespace Newtonsoft.Json.Bson
 {
@@ -76,31 +78,46 @@ namespace Newtonsoft.Json.Bson
             {
                 case BsonType.Object:
                     return WriteObjectAsync((BsonObject)t, cancellationToken);
+
                 case BsonType.Array:
                     return WriteArrayAsync((BsonArray)t, cancellationToken);
+
                 case BsonType.Integer:
                     return _asyncWriter.WriteAsync(Convert.ToInt32(((BsonValue)t).Value, CultureInfo.InvariantCulture), cancellationToken);
+
                 case BsonType.Long:
                     return _asyncWriter.WriteAsync(Convert.ToInt64(((BsonValue)t).Value, CultureInfo.InvariantCulture), cancellationToken);
+
                 case BsonType.Number:
                     return _asyncWriter.WriteAsync(Convert.ToDouble(((BsonValue)t).Value, CultureInfo.InvariantCulture), cancellationToken);
+
+                case BsonType.PrecisionNumber:
+                    return _asyncWriter.WriteAsync(Convert.ToDecimal(((BsonValue)t).Value, CultureInfo.InvariantCulture), cancellationToken);
+
                 case BsonType.String:
                     BsonString bsonString = (BsonString)t;
                     return WriteStringAsync((string)bsonString.Value, bsonString.ByteCount, bsonString.CalculatedSize - 4, cancellationToken);
+
                 case BsonType.Boolean:
                     return _asyncWriter.WriteAsync((bool)((BsonValue)t).Value, cancellationToken);
+
                 case BsonType.Null:
                 case BsonType.Undefined:
                     return AsyncUtils.CompletedTask;
+
                 case BsonType.Date:
                     BsonValue value = (BsonValue)t;
                     return _asyncWriter.WriteAsync(TicksFromDateObject(value.Value), cancellationToken);
+
                 case BsonType.Binary:
                     return WriteBinaryAsync((BsonBinary)t, cancellationToken);
+
                 case BsonType.Oid:
                     return _asyncWriter.WriteAsync((byte[])((BsonValue)t).Value, cancellationToken);
+
                 case BsonType.Regex:
                     return WriteRegexAsync((BsonRegex)t, cancellationToken);
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(t), "Unexpected token when writing BSON: {0}".FormatWith(CultureInfo.InvariantCulture, t.Type));
             }

--- a/Src/Newtonsoft.Json.Bson/BsonBinaryWriter.cs
+++ b/Src/Newtonsoft.Json.Bson/BsonBinaryWriter.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // Copyright (c) 2017 James Newton-King
 //
 // Permission is hereby granted, free of charge, to any person
@@ -21,13 +22,14 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-#endregion
 
+#endregion License
+
+using Newtonsoft.Json.Bson.Utilities;
 using System;
 using System.Globalization;
 using System.IO;
 using System.Text;
-using Newtonsoft.Json.Bson.Utilities;
 
 namespace Newtonsoft.Json.Bson
 {
@@ -75,95 +77,115 @@ namespace Newtonsoft.Json.Bson
             switch (t.Type)
             {
                 case BsonType.Object:
-                {
-                    BsonObject value = (BsonObject)t;
-                    _writer.Write(value.CalculatedSize);
-                    foreach (BsonProperty property in value)
                     {
-                        _writer.Write((sbyte)property.Value.Type);
-                        WriteString((string)property.Name.Value, property.Name.ByteCount, null);
-                        WriteTokenInternal(property.Value);
+                        BsonObject value = (BsonObject)t;
+                        _writer.Write(value.CalculatedSize);
+                        foreach (BsonProperty property in value)
+                        {
+                            _writer.Write((sbyte)property.Value.Type);
+                            WriteString((string)property.Name.Value, property.Name.ByteCount, null);
+                            WriteTokenInternal(property.Value);
+                        }
+                        _writer.Write((byte)0);
                     }
-                    _writer.Write((byte)0);
-                }
                     break;
+
                 case BsonType.Array:
-                {
-                    BsonArray value = (BsonArray)t;
-                    _writer.Write(value.CalculatedSize);
-                    ulong index = 0;
-                    foreach (BsonToken c in value)
                     {
-                        _writer.Write((sbyte)c.Type);
-                        WriteString(index.ToString(CultureInfo.InvariantCulture), MathUtils.IntLength(index), null);
-                        WriteTokenInternal(c);
-                        index++;
+                        BsonArray value = (BsonArray)t;
+                        _writer.Write(value.CalculatedSize);
+                        ulong index = 0;
+                        foreach (BsonToken c in value)
+                        {
+                            _writer.Write((sbyte)c.Type);
+                            WriteString(index.ToString(CultureInfo.InvariantCulture), MathUtils.IntLength(index), null);
+                            WriteTokenInternal(c);
+                            index++;
+                        }
+                        _writer.Write((byte)0);
                     }
-                    _writer.Write((byte)0);
-                }
                     break;
+
                 case BsonType.Integer:
-                {
-                    BsonValue value = (BsonValue)t;
-                    _writer.Write(Convert.ToInt32(value.Value, CultureInfo.InvariantCulture));
-                }
+                    {
+                        BsonValue value = (BsonValue)t;
+                        _writer.Write(Convert.ToInt32(value.Value, CultureInfo.InvariantCulture));
+                    }
                     break;
+
                 case BsonType.Long:
-                {
-                    BsonValue value = (BsonValue)t;
-                    _writer.Write(Convert.ToInt64(value.Value, CultureInfo.InvariantCulture));
-                }
+                    {
+                        BsonValue value = (BsonValue)t;
+                        _writer.Write(Convert.ToInt64(value.Value, CultureInfo.InvariantCulture));
+                    }
                     break;
+
                 case BsonType.Number:
-                {
-                    BsonValue value = (BsonValue)t;
-                    _writer.Write(Convert.ToDouble(value.Value, CultureInfo.InvariantCulture));
-                }
+                    {
+                        BsonValue value = (BsonValue)t;
+                        _writer.Write(Convert.ToDouble(value.Value, CultureInfo.InvariantCulture));
+                    }
                     break;
+
+                case BsonType.PrecisionNumber:
+                    {
+                        BsonValue value = (BsonValue)t;
+
+                        _writer.Write(Convert.ToDecimal(value.Value, CultureInfo.InvariantCulture));
+                    }
+                    break;
+
                 case BsonType.String:
-                {
-                    BsonString value = (BsonString)t;
-                    WriteString((string)value.Value, value.ByteCount, value.CalculatedSize - 4);
-                }
+                    {
+                        BsonString value = (BsonString)t;
+                        WriteString((string)value.Value, value.ByteCount, value.CalculatedSize - 4);
+                    }
                     break;
+
                 case BsonType.Boolean:
                     _writer.Write(t == BsonBoolean.True);
                     break;
+
                 case BsonType.Null:
                 case BsonType.Undefined:
                     break;
+
                 case BsonType.Date:
-                {
-                    BsonValue value = (BsonValue)t;
-                    _writer.Write(TicksFromDateObject(value.Value));
-                }
+                    {
+                        BsonValue value = (BsonValue)t;
+                        _writer.Write(TicksFromDateObject(value.Value));
+                    }
                     break;
+
                 case BsonType.Binary:
-                {
-                    BsonBinary value = (BsonBinary)t;
+                    {
+                        BsonBinary value = (BsonBinary)t;
 
-                    byte[] data = (byte[])value.Value;
-                    _writer.Write(data.Length);
-                    _writer.Write((byte)value.BinaryType);
-                    _writer.Write(data);
-                }
+                        byte[] data = (byte[])value.Value;
+                        _writer.Write(data.Length);
+                        _writer.Write((byte)value.BinaryType);
+                        _writer.Write(data);
+                    }
                     break;
+
                 case BsonType.Oid:
-                {
-                    BsonValue value = (BsonValue)t;
+                    {
+                        BsonValue value = (BsonValue)t;
 
-                    byte[] data = (byte[])value.Value;
-                    _writer.Write(data);
-                }
+                        byte[] data = (byte[])value.Value;
+                        _writer.Write(data);
+                    }
                     break;
+
                 case BsonType.Regex:
-                {
-                    BsonRegex value = (BsonRegex)t;
+                    {
+                        BsonRegex value = (BsonRegex)t;
 
-                    WriteString((string)value.Pattern.Value, value.Pattern.ByteCount, null);
-                    WriteString((string)value.Options.Value, value.Options.ByteCount, null);
-                }
+                        WriteString((string)value.Pattern.Value, value.Pattern.ByteCount, null);
+                        WriteString((string)value.Options.Value, value.Options.ByteCount, null);
+                    }
                     break;
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(t), "Unexpected token when writing BSON: {0}".FormatWith(CultureInfo.InvariantCulture, t.Type));
             }
@@ -244,83 +266,93 @@ namespace Newtonsoft.Json.Bson
             switch (t.Type)
             {
                 case BsonType.Object:
-                {
-                    BsonObject value = (BsonObject)t;
-
-                    int bases = 4;
-                    foreach (BsonProperty p in value)
                     {
-                        int size = 1;
-                        size += CalculateSize(p.Name);
-                        size += CalculateSize(p.Value);
+                        BsonObject value = (BsonObject)t;
 
-                        bases += size;
+                        int bases = 4;
+                        foreach (BsonProperty p in value)
+                        {
+                            int size = 1;
+                            size += CalculateSize(p.Name);
+                            size += CalculateSize(p.Value);
+
+                            bases += size;
+                        }
+                        bases += 1;
+                        value.CalculatedSize = bases;
+                        return bases;
                     }
-                    bases += 1;
-                    value.CalculatedSize = bases;
-                    return bases;
-                }
                 case BsonType.Array:
-                {
-                    BsonArray value = (BsonArray)t;
-
-                    int size = 4;
-                    ulong index = 0;
-                    foreach (BsonToken c in value)
                     {
-                        size += 1;
-                        size += CalculateSize(MathUtils.IntLength(index));
-                        size += CalculateSize(c);
-                        index++;
-                    }
-                    size += 1;
-                    value.CalculatedSize = size;
+                        BsonArray value = (BsonArray)t;
 
-                    return value.CalculatedSize;
-                }
+                        int size = 4;
+                        ulong index = 0;
+                        foreach (BsonToken c in value)
+                        {
+                            size += 1;
+                            size += CalculateSize(MathUtils.IntLength(index));
+                            size += CalculateSize(c);
+                            index++;
+                        }
+                        size += 1;
+                        value.CalculatedSize = size;
+
+                        return value.CalculatedSize;
+                    }
                 case BsonType.Integer:
                     return 4;
+
                 case BsonType.Long:
                     return 8;
+
                 case BsonType.Number:
                     return 8;
-                case BsonType.String:
-                {
-                    BsonString value = (BsonString)t;
-                    string s = (string)value.Value;
-                    value.ByteCount = (s != null) ? Encoding.GetByteCount(s) : 0;
-                    value.CalculatedSize = CalculateSizeWithLength(value.ByteCount, value.IncludeLength);
 
-                    return value.CalculatedSize;
-                }
+                case BsonType.PrecisionNumber:
+                    return 8;
+
+                case BsonType.String:
+                    {
+                        BsonString value = (BsonString)t;
+                        string s = (string)value.Value;
+                        value.ByteCount = (s != null) ? Encoding.GetByteCount(s) : 0;
+                        value.CalculatedSize = CalculateSizeWithLength(value.ByteCount, value.IncludeLength);
+
+                        return value.CalculatedSize;
+                    }
                 case BsonType.Boolean:
                     return 1;
+
                 case BsonType.Null:
                 case BsonType.Undefined:
                     return 0;
+
                 case BsonType.Date:
                     return 8;
+
                 case BsonType.Binary:
-                {
-                    BsonBinary value = (BsonBinary)t;
+                    {
+                        BsonBinary value = (BsonBinary)t;
 
-                    byte[] data = (byte[])value.Value;
-                    value.CalculatedSize = 4 + 1 + data.Length;
+                        byte[] data = (byte[])value.Value;
+                        value.CalculatedSize = 4 + 1 + data.Length;
 
-                    return value.CalculatedSize;
-                }
+                        return value.CalculatedSize;
+                    }
                 case BsonType.Oid:
                     return 12;
-                case BsonType.Regex:
-                {
-                    BsonRegex value = (BsonRegex)t;
-                    int size = 0;
-                    size += CalculateSize(value.Pattern);
-                    size += CalculateSize(value.Options);
-                    value.CalculatedSize = size;
 
-                    return value.CalculatedSize;
-                }
+                case BsonType.Regex:
+                    {
+                        BsonRegex value = (BsonRegex)t;
+                        int size = 0;
+                        size += CalculateSize(value.Pattern);
+                        size += CalculateSize(value.Options);
+                        value.CalculatedSize = size;
+
+                        return value.CalculatedSize;
+                    }
                 default:
                     throw new ArgumentOutOfRangeException(nameof(t), "Unexpected token when writing BSON: {0}".FormatWith(CultureInfo.InvariantCulture, t.Type));
             }

--- a/Src/Newtonsoft.Json.Bson/BsonDataReader.cs
+++ b/Src/Newtonsoft.Json.Bson/BsonDataReader.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // Copyright (c) 2017 James Newton-King
 //
 // Permission is hereby granted, free of charge, to any person
@@ -21,15 +22,15 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-#endregion
 
+#endregion License
+
+using Newtonsoft.Json.Bson.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using System.IO;
-using Newtonsoft.Json.Bson.Utilities;
-using Newtonsoft.Json.Linq;
+using System.Text;
 
 namespace Newtonsoft.Json.Bson
 {
@@ -204,11 +205,13 @@ namespace Newtonsoft.Json.Bson
                     case BsonReaderState.Normal:
                         success = ReadNormal();
                         break;
+
                     case BsonReaderState.ReferenceStart:
                     case BsonReaderState.ReferenceRef:
                     case BsonReaderState.ReferenceId:
                         success = ReadReference();
                         break;
+
                     case BsonReaderState.CodeWScopeStart:
                     case BsonReaderState.CodeWScopeCode:
                     case BsonReaderState.CodeWScopeScope:
@@ -216,6 +219,7 @@ namespace Newtonsoft.Json.Bson
                     case BsonReaderState.CodeWScopeScopeEnd:
                         success = ReadCodeWScope();
                         break;
+
                     default:
                         throw ExceptionUtils.CreateJsonReaderException(this, "Unexpected state: {0}".FormatWith(CultureInfo.InvariantCulture, _bsonReaderState));
                 }
@@ -261,13 +265,16 @@ namespace Newtonsoft.Json.Bson
                     SetToken(JsonToken.PropertyName, "$code");
                     _bsonReaderState = BsonReaderState.CodeWScopeCode;
                     return true;
+
                 case BsonReaderState.CodeWScopeCode:
+
                     // total CodeWScope size - not used
                     ReadInt32();
 
                     SetToken(JsonToken.String, ReadLengthString());
                     _bsonReaderState = BsonReaderState.CodeWScopeScope;
                     return true;
+
                 case BsonReaderState.CodeWScopeScope:
                     if (CurrentState == State.PostValue)
                     {
@@ -293,10 +300,12 @@ namespace Newtonsoft.Json.Bson
                     }
 
                     return result;
+
                 case BsonReaderState.CodeWScopeScopeEnd:
                     SetToken(JsonToken.EndObject);
                     _bsonReaderState = BsonReaderState.Normal;
                     return true;
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -307,47 +316,47 @@ namespace Newtonsoft.Json.Bson
             switch (CurrentState)
             {
                 case State.ObjectStart:
-                {
-                    SetToken(JsonToken.PropertyName, "$ref");
-                    _bsonReaderState = BsonReaderState.ReferenceRef;
-                    return true;
-                }
+                    {
+                        SetToken(JsonToken.PropertyName, "$ref");
+                        _bsonReaderState = BsonReaderState.ReferenceRef;
+                        return true;
+                    }
                 case State.Property:
-                {
-                    if (_bsonReaderState == BsonReaderState.ReferenceRef)
                     {
-                        SetToken(JsonToken.String, ReadLengthString());
-                        return true;
+                        if (_bsonReaderState == BsonReaderState.ReferenceRef)
+                        {
+                            SetToken(JsonToken.String, ReadLengthString());
+                            return true;
+                        }
+                        else if (_bsonReaderState == BsonReaderState.ReferenceId)
+                        {
+                            SetToken(JsonToken.Bytes, ReadBytes(12));
+                            return true;
+                        }
+                        else
+                        {
+                            throw ExceptionUtils.CreateJsonReaderException(this, "Unexpected state when reading BSON reference: " + _bsonReaderState);
+                        }
                     }
-                    else if (_bsonReaderState == BsonReaderState.ReferenceId)
-                    {
-                        SetToken(JsonToken.Bytes, ReadBytes(12));
-                        return true;
-                    }
-                    else
-                    {
-                        throw ExceptionUtils.CreateJsonReaderException(this, "Unexpected state when reading BSON reference: " + _bsonReaderState);
-                    }
-                }
                 case State.PostValue:
-                {
-                    if (_bsonReaderState == BsonReaderState.ReferenceRef)
                     {
-                        SetToken(JsonToken.PropertyName, "$id");
-                        _bsonReaderState = BsonReaderState.ReferenceId;
-                        return true;
+                        if (_bsonReaderState == BsonReaderState.ReferenceRef)
+                        {
+                            SetToken(JsonToken.PropertyName, "$id");
+                            _bsonReaderState = BsonReaderState.ReferenceId;
+                            return true;
+                        }
+                        else if (_bsonReaderState == BsonReaderState.ReferenceId)
+                        {
+                            SetToken(JsonToken.EndObject);
+                            _bsonReaderState = BsonReaderState.Normal;
+                            return true;
+                        }
+                        else
+                        {
+                            throw ExceptionUtils.CreateJsonReaderException(this, "Unexpected state when reading BSON reference: " + _bsonReaderState);
+                        }
                     }
-                    else if (_bsonReaderState == BsonReaderState.ReferenceId)
-                    {
-                        SetToken(JsonToken.EndObject);
-                        _bsonReaderState = BsonReaderState.Normal;
-                        return true;
-                    }
-                    else
-                    {
-                        throw ExceptionUtils.CreateJsonReaderException(this, "Unexpected state when reading BSON reference: " + _bsonReaderState);
-                    }
-                }
                 default:
                     throw ExceptionUtils.CreateJsonReaderException(this, "Unexpected state when reading BSON reference: " + CurrentState);
             }
@@ -358,24 +367,25 @@ namespace Newtonsoft.Json.Bson
             switch (CurrentState)
             {
                 case State.Start:
-                {
-                    JsonToken token = (!_readRootValueAsArray) ? JsonToken.StartObject : JsonToken.StartArray;
-                    BsonType type = (!_readRootValueAsArray) ? BsonType.Object : BsonType.Array;
+                    {
+                        JsonToken token = (!_readRootValueAsArray) ? JsonToken.StartObject : JsonToken.StartArray;
+                        BsonType type = (!_readRootValueAsArray) ? BsonType.Object : BsonType.Array;
 
-                    SetToken(token);
-                    ContainerContext newContext = new ContainerContext(type);
-                    PushContext(newContext);
-                    newContext.Length = ReadInt32();
-                    return true;
-                }
+                        SetToken(token);
+                        ContainerContext newContext = new ContainerContext(type);
+                        PushContext(newContext);
+                        newContext.Length = ReadInt32();
+                        return true;
+                    }
                 case State.Complete:
                 case State.Closed:
                     return false;
+
                 case State.Property:
-                {
-                    ReadType(_currentElementType);
-                    return true;
-                }
+                    {
+                        ReadType(_currentElementType);
+                        return true;
+                    }
                 case State.ObjectStart:
                 case State.ArrayStart:
                 case State.PostValue:
@@ -429,12 +439,16 @@ namespace Newtonsoft.Json.Bson
                     }
                 case State.ConstructorStart:
                     break;
+
                 case State.Constructor:
                     break;
+
                 case State.Error:
                     break;
+
                 case State.Finished:
                     break;
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -483,28 +497,34 @@ namespace Newtonsoft.Json.Bson
                         SetToken(JsonToken.Float, d);
                     }
                     break;
+
+                case BsonType.PrecisionNumber:
+                    SetToken(JsonToken.Float, Convert.ToDecimal(ReadDecimal(), CultureInfo.InvariantCulture));
+                    break;
+
                 case BsonType.String:
                 case BsonType.Symbol:
                     SetToken(JsonToken.String, ReadLengthString());
                     break;
+
                 case BsonType.Object:
-                {
-                    SetToken(JsonToken.StartObject);
+                    {
+                        SetToken(JsonToken.StartObject);
 
-                    ContainerContext newContext = new ContainerContext(BsonType.Object);
-                    PushContext(newContext);
-                    newContext.Length = ReadInt32();
-                    break;
-                }
+                        ContainerContext newContext = new ContainerContext(BsonType.Object);
+                        PushContext(newContext);
+                        newContext.Length = ReadInt32();
+                        break;
+                    }
                 case BsonType.Array:
-                {
-                    SetToken(JsonToken.StartArray);
+                    {
+                        SetToken(JsonToken.StartArray);
 
-                    ContainerContext newContext = new ContainerContext(BsonType.Array);
-                    PushContext(newContext);
-                    newContext.Length = ReadInt32();
-                    break;
-                }
+                        ContainerContext newContext = new ContainerContext(BsonType.Array);
+                        PushContext(newContext);
+                        newContext.Length = ReadInt32();
+                        break;
+                    }
                 case BsonType.Binary:
                     BsonBinaryType binaryType;
                     byte[] data = ReadBinary(out binaryType);
@@ -515,17 +535,21 @@ namespace Newtonsoft.Json.Bson
 
                     SetToken(JsonToken.Bytes, value);
                     break;
+
                 case BsonType.Undefined:
                     SetToken(JsonToken.Undefined);
                     break;
+
                 case BsonType.Oid:
                     byte[] oid = ReadBytes(12);
                     SetToken(JsonToken.Bytes, oid);
                     break;
+
                 case BsonType.Boolean:
                     bool b = Convert.ToBoolean(ReadByte());
                     SetToken(JsonToken.Boolean, b);
                     break;
+
                 case BsonType.Date:
                     long ticks = ReadInt64();
                     DateTime utcDateTime = DateTimeUtils.ConvertJavaScriptTicksToDateTime(ticks);
@@ -536,9 +560,11 @@ namespace Newtonsoft.Json.Bson
                         case DateTimeKind.Unspecified:
                             dateTime = DateTime.SpecifyKind(utcDateTime, DateTimeKind.Unspecified);
                             break;
+
                         case DateTimeKind.Local:
                             dateTime = utcDateTime.ToLocalTime();
                             break;
+
                         default:
                             dateTime = utcDateTime;
                             break;
@@ -546,9 +572,11 @@ namespace Newtonsoft.Json.Bson
 
                     SetToken(JsonToken.Date, dateTime);
                     break;
+
                 case BsonType.Null:
                     SetToken(JsonToken.Null);
                     break;
+
                 case BsonType.Regex:
                     string expression = ReadString();
                     string modifiers = ReadString();
@@ -556,24 +584,30 @@ namespace Newtonsoft.Json.Bson
                     string regex = @"/" + expression + @"/" + modifiers;
                     SetToken(JsonToken.String, regex);
                     break;
+
                 case BsonType.Reference:
                     SetToken(JsonToken.StartObject);
                     _bsonReaderState = BsonReaderState.ReferenceStart;
                     break;
+
                 case BsonType.Code:
                     SetToken(JsonToken.String, ReadLengthString());
                     break;
+
                 case BsonType.CodeWScope:
                     SetToken(JsonToken.StartObject);
                     _bsonReaderState = BsonReaderState.CodeWScopeStart;
                     break;
+
                 case BsonType.Integer:
                     SetToken(JsonToken.Integer, (long)ReadInt32());
                     break;
+
                 case BsonType.TimeStamp:
                 case BsonType.Long:
                     SetToken(JsonToken.Integer, ReadInt64());
                     break;
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type), "Unexpected BsonType value: " + type);
             }
@@ -586,6 +620,7 @@ namespace Newtonsoft.Json.Bson
             binaryType = (BsonBinaryType)ReadByte();
 
 #pragma warning disable 612,618
+
             // the old binary type has the data length repeated in the data for some reason
             if (binaryType == BsonBinaryType.BinaryOld && !_jsonNet35BinaryCompatibility)
             {
@@ -603,6 +638,7 @@ namespace Newtonsoft.Json.Bson
             StringBuilder builder = null;
 
             int totalBytesRead = 0;
+
             // used in case of left over multibyte characters in the buffer
             int offset = 0;
             while (true)
@@ -642,6 +678,7 @@ namespace Newtonsoft.Json.Bson
                     if (lastFullCharStop < byteCount - 1)
                     {
                         offset = byteCount - lastFullCharStop - 1;
+
                         // copy left over multi byte characters to beginning of buffer for next iteration
                         Array.Copy(_byteBuffer, lastFullCharStop + 1, _byteBuffer, 0, offset);
                     }
@@ -728,6 +765,7 @@ namespace Newtonsoft.Json.Bson
                     if (lastFullCharStop < byteCount - 1)
                     {
                         offset = byteCount - lastFullCharStop - 1;
+
                         // copy left over multi byte characters to beginning of buffer for next iteration
                         Array.Copy(_byteBuffer, lastFullCharStop + 1, _byteBuffer, 0, offset);
                     }
@@ -812,6 +850,12 @@ namespace Newtonsoft.Json.Bson
         {
             MovePosition(8);
             return _reader.ReadDouble();
+        }
+
+        private decimal ReadDecimal()
+        {
+            MovePosition(8);
+            return _reader.ReadDecimal();
         }
 
         private int ReadInt32()

--- a/Src/Newtonsoft.Json.Bson/BsonDataWriter.cs
+++ b/Src/Newtonsoft.Json.Bson/BsonDataWriter.cs
@@ -1,4 +1,5 @@
 #region License
+
 // Copyright (c) 2017 James Newton-King
 //
 // Permission is hereby granted, free of charge, to any person
@@ -21,18 +22,19 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-#endregion
+
+#endregion License
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.IO;
+
 #if HAVE_BIG_INTEGER
+
 using System.Numerics;
+
 #endif
-using System.Text;
+
 using Newtonsoft.Json.Bson.Utilities;
-using Newtonsoft.Json.Linq;
 using System.Globalization;
 
 namespace Newtonsoft.Json.Bson
@@ -250,6 +252,7 @@ namespace Newtonsoft.Json.Bson
         }
 
         #region WriteValue methods
+
         /// <summary>
         /// Writes a <see cref="Object"/> value.
         /// An error will raised if the value cannot be written as a single JSON token.
@@ -445,7 +448,7 @@ namespace Newtonsoft.Json.Bson
         public override void WriteValue(decimal value)
         {
             base.WriteValue(value);
-            AddValue(value, BsonType.Number);
+            AddValue(value, BsonType.PrecisionNumber);
         }
 
         /// <summary>
@@ -460,6 +463,7 @@ namespace Newtonsoft.Json.Bson
         }
 
 #if HAVE_DATE_TIME_OFFSET
+
         /// <summary>
         /// Writes a <see cref="DateTimeOffset"/> value.
         /// </summary>
@@ -469,6 +473,7 @@ namespace Newtonsoft.Json.Bson
             base.WriteValue(value);
             AddValue(value, BsonType.Date);
         }
+
 #endif
 
         /// <summary>
@@ -522,7 +527,8 @@ namespace Newtonsoft.Json.Bson
             base.WriteValue(value);
             AddToken(new BsonString(value.ToString(), true));
         }
-        #endregion
+
+        #endregion WriteValue methods
 
         /// <summary>
         /// Writes a <see cref="Byte"/>[] value that represents a BSON object id.

--- a/Src/Newtonsoft.Json.Bson/BsonType.cs
+++ b/Src/Newtonsoft.Json.Bson/BsonType.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // Copyright (c) 2017 James Newton-King
 //
 // Permission is hereby granted, free of charge, to any person
@@ -21,7 +22,8 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-#endregion
+
+#endregion License
 
 namespace Newtonsoft.Json.Bson
 {
@@ -45,6 +47,7 @@ namespace Newtonsoft.Json.Bson
         Integer = 16,
         TimeStamp = 17,
         Long = 18,
+        PrecisionNumber = 19,
         MinKey = -1,
         MaxKey = 127
     }


### PR DESCRIPTION
Current serialization of decimal types using Bson is that they're serialized as doubles. Unfortunately this results in a some of the precision being lost.
For example -28.6051368556538258 when serialized and deserialized comes out as -28.605136855653
The changes included here promote decimal as a different bson type to allow it to be serialized with more precision.