### PR TITLE
Fix memory leak because of static instances for Null,Undefined, True and False

### DIFF
--- a/Src/Newtonsoft.Json.Bson/BsonBinaryWriter.cs
+++ b/Src/Newtonsoft.Json.Bson/BsonBinaryWriter.cs
@@ -127,7 +127,10 @@ namespace Newtonsoft.Json.Bson
                 }
                     break;
                 case BsonType.Boolean:
-                    _writer.Write(t == BsonBoolean.True);
+                {
+                    BsonBoolean value = (BsonBoolean)t;
+                    _writer.Write((bool)value.Value);
+                }
                     break;
                 case BsonType.Null:
                 case BsonType.Undefined:

--- a/Src/Newtonsoft.Json.Bson/BsonDataWriter.cs
+++ b/Src/Newtonsoft.Json.Bson/BsonDataWriter.cs
@@ -276,7 +276,7 @@ namespace Newtonsoft.Json.Bson
         public override void WriteNull()
         {
             base.WriteNull();
-            AddToken(BsonEmpty.Null);
+            AddToken(new BsonEmpty(BsonType.Null));
         }
 
         /// <summary>
@@ -285,7 +285,7 @@ namespace Newtonsoft.Json.Bson
         public override void WriteUndefined()
         {
             base.WriteUndefined();
-            AddToken(BsonEmpty.Undefined);
+            AddToken(new BsonEmpty(BsonType.Undefined));
         }
 
         /// <summary>
@@ -295,7 +295,7 @@ namespace Newtonsoft.Json.Bson
         public override void WriteValue(string value)
         {
             base.WriteValue(value);
-            AddToken(value == null ? BsonEmpty.Null : new BsonString(value, true));
+            AddToken(value == null ? ((BsonToken)new BsonEmpty(BsonType.Null)) : new BsonString(value, true));
         }
 
         /// <summary>
@@ -377,7 +377,7 @@ namespace Newtonsoft.Json.Bson
         public override void WriteValue(bool value)
         {
             base.WriteValue(value);
-            AddToken(value ? BsonBoolean.True : BsonBoolean.False);
+            AddToken(value ? new BsonBoolean(true) : new BsonBoolean(false));
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json.Bson/BsonToken.cs
+++ b/Src/Newtonsoft.Json.Bson/BsonToken.cs
@@ -89,10 +89,10 @@ namespace Newtonsoft.Json.Bson
 
     internal class BsonEmpty : BsonToken
     {
-        public static readonly BsonToken Null = new BsonEmpty(BsonType.Null);
-        public static readonly BsonToken Undefined = new BsonEmpty(BsonType.Undefined);
+        //public static readonly BsonToken Null = new BsonEmpty(BsonType.Null);
+        //public static readonly BsonToken Undefined = new BsonEmpty(BsonType.Undefined);
 
-        private BsonEmpty(BsonType type)
+        public BsonEmpty(BsonType type)
         {
             Type = type;
         }
@@ -124,10 +124,10 @@ namespace Newtonsoft.Json.Bson
 
     internal class BsonBoolean : BsonValue
     {
-        public static readonly BsonBoolean False = new BsonBoolean(false);
-        public static readonly BsonBoolean True = new BsonBoolean(true);
+        //public static readonly BsonBoolean False = new BsonBoolean(false);
+        //public static readonly BsonBoolean True = new BsonBoolean(true);
 
-        private BsonBoolean(bool value)
+        public BsonBoolean(bool value)
             : base(value, BsonType.Boolean)
         {
         }


### PR DESCRIPTION
I understand that the static isntances  for Null, Undefined, True and False were probably created to save memory during parsing, but because of the Parent property after the bson is finished writing/reading the whole bson tree hierarchy stay in memory forever or until the next call of the library and the garbage collector collects the previous tree( leaving the last tree in memory)...

I am using this nuget in a xamarin android application and i am often have about 40Megabytes that stays permanently in memory because of this, even when the app in put into background which is rather problematic on low end android devices.


I also see that the algorithm use the Parent property to determine something in `WillClose` method, i did not understand how the library works in detail but i wonder if the algorithm is correct if the parent of all these four values always change and does not reflect the true tree structure ?
(if this does not matter (which is probably the case because i never noticed a bug while using this library for a long time?) maybe we could imagine keeping the optimization but instead of putting the values in static variables we could put them in the reader and writer instance )

